### PR TITLE
Added support to turn off lights that were manually turned on and minor bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,11 @@ key | optional | type | default | description
 `class` | False | string | AutoMoLi | The name of the Class.
 `room` | False | string | | The "room" used to find matching sensors/light
 `disable_switch_entities` | True | list/string | | One or more Home Assistant Entities as switch for AutoMoLi. If the state of **any** entity is *off*, AutoMoLi is *deactivated*. (Use an *input_boolean* for example)
-`only_own_events` | True | bool | | Track if automoli switched this light on. If not, an existing timer will be deleted and the state will not change
+`only_own_events` | True | bool | None | Track if automoli switched this light on. If not, automoli will not switch the light off. (see below)
 `disable_switch_states` | True | list/string | ["off"] | Custom states for `disable_switch_entities`. If the state of **any** entity is *in this list*, AutoMoLi is *deactivated*. Can be used to disable with `media_players` in `playing` state for example.
 `disable_hue_groups` | False | boolean | | Disable the use of Hue Groups/Scenes
 `delay` | True | integer | 150 | Seconds without motion until lights will switched off. Can be disabled (lights stay always on) with `0`
+`delay_outside_events` | True | integer | same as delay | Seconds without motion until lights will switched off, if they were turned on by an event outside automoli (e.g., manually, via automation, etc.). Can be disabled (lights stay always on) with `0`
 ~~`motion_event`~~ | ~~True~~ | ~~string~~ | | **replaced by `motion_state_on/off`**
 `daytimes` | True | list | *see code* | Different daytimes with light settings (see below)
 `transition_on_daytime_switch` | True | bool | False | directly activate a daytime on its start time (instead to just set it as active daytime used if lights are switched from off to on)
@@ -162,6 +163,14 @@ key | optional | type | default | description
 `name` | False | string | | A name for this daytime
 `delay` | True | integer | 150 | Seconds without motion until lights will switched off. Can be disabled (lights stay always on) with `0`. Setting this will overwrite the global `delay` setting for this daytime.
 `light` | False | integer/string | | Light setting (percent integer value (0-100) in or scene entity
+
+### only_own_events
+
+state | description
+-- | --
+None | Lights will be turned off after motion is detected, regardless of whether AutoMoLi turned the lights on.
+False | Lights will be turned off after motion is detected, regardless of whether AutoMoLi turned the lights on AND after the delay if they were turned on outside AutoMoLi (e.g., manually or via an automation). 
+True | Lights will only be turned off after motion is detected, if AutoMoLi turned the lights on.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ key | optional | type | default | description
 `illuminance_threshold` | True | integer |  | If illuminance is *above* this value, lights will *not switched on*
 `humidity` | True | list/string |  | Humidity sensor entities
 `humidity_threshold` | True | integer |  | If humidity is *above* this value, lights will *not switched off*
-`motion_state_on` | True | integer | | If using motion sensors which don't send events if already activated, like Xiaomi do, add this to your config with "on". This will listen to state changes instead
-`motion_state_off` | True | integer | | If using motion sensors which don't send events if already activated, like Xiaomi do, add this to your config with "off". This will listen to the state changes instead.
+`motion_state_on` | True | integer | | If using motion sensors which don't send events if already activated, like Xiaomi do with the Xiaomi Gateway (Aqara) integration, add this to your config with "on". This will listen to state changes instead
+`motion_state_off` | True | integer | | If using motion sensors which don't send events if already activated, like Xiaomi do with the Xiaomi Gateway (Aqara) integration, add this to your config with "off". This will listen to the state changes instead
 `debug_log` | True | bool | false | Activate debug logging (for this room)
 
 ### daytimes
@@ -163,6 +163,8 @@ key | optional | type | default | description
 `name` | False | string | | A name for this daytime
 `delay` | True | integer | 150 | Seconds without motion until lights will switched off. Can be disabled (lights stay always on) with `0`. Setting this will overwrite the global `delay` setting for this daytime.
 `light` | False | integer/string | | Light setting (percent integer value (0-100) in or scene entity
+
+Note: If there is only one daytime, the light and delay settings will be applied for the entire day, regardless of the starttime.
 
 ### only_own_events
 

--- a/apps/automoli/automoli.py
+++ b/apps/automoli/automoli.py
@@ -468,6 +468,9 @@ class AutoMoLi(hass.Hass):  # type: ignore
                         new="on",
                     )
                 )
+                # assume any lights that are currently on were switched on by AutoMoLi
+                if await self.get_state(light) == "on":
+                    self._switched_on_by_automoli.add(light)
 
         self.args.update(
             {

--- a/apps/automoli/automoli.py
+++ b/apps/automoli/automoli.py
@@ -952,8 +952,7 @@ class AutoMoLi(hass.Hass):  # type: ignore
                         group_name=await self.friendly_name(entity),  # type:ignore
                         scene_name=light_setting,  # type:ignore
                     )
-                    if self.only_own_events:
-                        self._switched_on_by_automoli.add(entity)
+                    self._switched_on_by_automoli.add(entity)
                     continue
 
                 item = light_setting if light_setting.startswith("scene.") else entity
@@ -961,8 +960,7 @@ class AutoMoLi(hass.Hass):  # type: ignore
                 await self.call_service(
                     "homeassistant/turn_on", entity_id=item  # type:ignore
                 )  # type:ignore
-                if self.only_own_events:
-                    self._switched_on_by_automoli.add(item)
+                self._switched_on_by_automoli.add(item)
 
             self.lg(
                 f"{hl(self.room.name.capitalize())} turned {hl('on')} → "
@@ -1003,8 +1001,7 @@ class AutoMoLi(hass.Hass):  # type: ignore
                         f" | delay: {hl(natural_time(int(self.active['delay'])))}",
                         icon=ON_ICON,
                     )
-                    if self.only_own_events:
-                        self._switched_on_by_automoli.add(entity)
+                    self._switched_on_by_automoli.add(entity)
 
         else:
             raise ValueError(


### PR DESCRIPTION
Fixes #24:  If only_own_events is False, then added state change listeners for all lights. Then, when a state change occurs outside automoli, manually setup the timers. Also added an additional, optional config property, delay_outside_events, that if present will override the standard delay in the cases when the light has been turned on manually.

delay_outside_events is useful, for example, when you want lights to go off quickly when turned on automatically, but have a longer delay if a light switch is used. I have a 3 minute delay in a hallway (assuming someone is just passing through) but have set delay_outside_events to 15 minutes if the light switch is used (and someone might need to linger in the hallway).

In an attempt to minimize backward compatibility issues, the code assumes that if only_own_events is not present in the config, it is None and not False.

Additionally, applied bug fixes for handling multiple lights, one daytime, and minor log/readme cleanup:
- Ensure that if a room has multiple lights, all lights will be turned on based on motion events
- [Workaround for issue #86]  Allow a single daytime such as:
  {starttime: "00:00", name: "allday", light: 100}
- Clarified in documentation that motion events are only sent if you have the Xioami Gateway integration (not just if you have Xioami / Aqara motion sensors)
- Added and made minor updates to a few log statements to help with debugging 