### PR TITLE
Add support for room/bathroom doors

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ bathroom:
     - switch.plug_68fe8b4c9fa1
   motion:
     - binary_sensor.motion_sensor_158d033224e141
+  # For the bathroom leave the light on as long as the door is closed
+  door:
+    - binary_sensor.bathroom_door
+  # Optional : When the door opens turn off the light after specified delay
+  door_open_delay: 10
 ```
 
 ## Auto-Discovery of Lights and Sensors
@@ -152,6 +157,8 @@ key | optional | type | default | description
 `humidity_threshold` | True | integer |  | If humidity is *above* this value, lights will *not switched off*
 `motion_state_on` | True | integer | | If using motion sensors which don't send events if already activated, like Xiaomi do, add this to your config with "on". This will listen to state changes instead
 `motion_state_off` | True | integer | | If using motion sensors which don't send events if already activated, like Xiaomi do, add this to your config with "off". This will listen to the state changes instead.
+`door` | True | list/string | | Door close sensor, light will not turn off when door is closed
+`door_open_delay` | True | integer | | Override normal delay when door is opened
 `debug_log` | True | bool | false | Activate debug logging (for this room)
 
 ### daytimes


### PR DESCRIPTION
This adds support to specify the doors to the room.  As long as that door
is closed the light will be blocked from turning off.  Closing the door
is also treated as a motion event and will cause the light to turn on.

You can also override the default delay to have the light turn off
quicker after the door is opened by specifying 'door_open_delay' otherwise
it will turn off after the normal delay

Additional config options:
  door:
    - binary_sensor.bathroom_door
  door_open_delay: 5