### PR TITLE
Disable timezone aware parsing of time

### DIFF
--- a/apps/automoli/automoli.py
+++ b/apps/automoli/automoli.py
@@ -1087,7 +1087,7 @@ class AutoMoLi(hass.Hass):  # type: ignore
                 starttime = daytime.get("starttime")
                 if starttime.count(":") == 1:
                     starttime += ":00"
-                dt_start = (await self.parse_time(starttime, aware=True)).replace(
+                dt_start = (await self.parse_time(starttime)).replace(
                     microsecond=0
                 )
                 daytime["starttime"] = dt_start
@@ -1115,7 +1115,7 @@ class AutoMoLi(hass.Hass):  # type: ignore
                     next_starttime += ":00"
                 next_dt_name = str(daytimes[(idx + 1) % len(daytimes)].get("name"))
                 next_dt_start = (
-                    await self.parse_time(next_starttime, aware=True)
+                    await self.parse_time(next_starttime)
                 ).replace(microsecond=0)
             except ValueError as error:
                 raise ValueError(


### PR DESCRIPTION
This PR will fix #114 by disabling the awareness of timezones for the datetime objects this script creates. 

[Official Documentation](https://appdaemon.readthedocs.io/en/latest/AD_API_REFERENCE.html#appdaemon.adapi.ADAPI.parse_time) states that by default this is disabled.